### PR TITLE
fix: PostServiceImpl Null Safety 처리 개선

### DIFF
--- a/src/main/java/com/example/festimo/domain/post/service/PostServiceImpl.kt
+++ b/src/main/java/com/example/festimo/domain/post/service/PostServiceImpl.kt
@@ -111,7 +111,7 @@ class PostServiceImpl(
     @Transactional
     override fun updatePost(postId: Long, request: UpdatePostRequest): PostDetailResponse {
         val user = SecurityContextHolder.getContext().authentication?.name?.let { email ->
-            userRepository.findByEmail(email).orElseThrow { UnauthorizedException() }
+            userRepository.findByEmail(email) ?: throw UnauthorizedException()
         } ?: throw UnauthorizedException()
 
         val post = postRepository.findById(postId).orElseThrow { PostNotFound() }
@@ -196,7 +196,7 @@ class PostServiceImpl(
 
     override fun getComments(postId: Long): List<CommentResponse> {
         val user = SecurityContextHolder.getContext().authentication?.name?.let { email ->
-            userRepository.findByEmail(email).orElseThrow { UnauthorizedException() }
+            userRepository.findByEmail(email) ?: throw UnauthorizedException()
         } ?: throw UnauthorizedException()
 
         val post = postRepository.findById(postId).orElseThrow { PostNotFound() }
@@ -293,6 +293,6 @@ class PostServiceImpl(
             throw UnauthorizedException()
         }
         return userRepository.findByEmail(authentication.name)
-            .orElseThrow { UnauthorizedException() }
+            ?: throw UnauthorizedException()
     }
 }


### PR DESCRIPTION
- Java Optional을 Kotlin Nullable로 변경
- validateAuthenticationAndGetUser 메서드 Elvis 연산자 적용

<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
PostServiceImpl Null Safety 처리 개선
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- null 처리를 위한 Elvis 연산자 적용
- Optional의 orElseThrow 대신 Elvis 연산자 사용
-
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
